### PR TITLE
Add import support to ECI, ACI, CS, and map types for IP

### DIFF
--- a/map_types.py
+++ b/map_types.py
@@ -67,6 +67,18 @@ ARRAY_TYPES = {
         "Key": "",
         "Value": "ItemPrefab"
     },
+    "AuraEffectItems": {
+        "Key": "",
+        "Value": "RawData"
+    },
+    "BaseMakeItemSet": {
+        "Key": "",
+        "Value": "BaseMakeItem"
+    },
+    "ItemPrefabAccSet": {
+        "Key": "",
+        "Value": "ItemPrefab"
+    },
     "RawData": {
         "Key": "",
         "Value": "RawData"
@@ -351,6 +363,9 @@ FACTORY_MAP = {
     "AudioSynesthesiaNRTSettings": [
         "AudioSynesthesiaNRTSettingsFactory"
     ],
+    "AuraCharacterItem": [
+        "AuraCharacterItemFactory"
+    ],
     "BaseCharacterItem": [
         "BaseCharacterItemFactory"
     ],
@@ -472,6 +487,9 @@ FACTORY_MAP = {
     ],
     "EditorUtilityWidgetBlueprint": [
         "EditorUtilityWidgetBlueprintFactory"
+    ],
+    "EffectCharacterItem": [
+        "EffectCharacterItemFactory"
     ],
     "EndpointSubmix": [
         "EndpointSubmixFactory"

--- a/tekken8_batch_import.py
+++ b/tekken8_batch_import.py
@@ -29,10 +29,10 @@ def main():
     texture_root = r"D:\modding\T8\vanilla_textures"
 
     # TODO: Set this to root of Content in Fmodel JSON extraction folder, or to the root folder for the assets you want to batch import
-    export_root = r"D:\modding\T8_Demo\Exports\Polaris\Content\Character\Item"
+    export_root = r"D:\Programs\FModel\Output\Exports\Polaris\Content\Character\Item"
 
     #TODO:  Set file types to import
-    types_to_import = ['DYB_Param']
+    types_to_import = ['ECI']
 
     p = Path(export_root)
 

--- a/tekken8_import_utils.py
+++ b/tekken8_import_utils.py
@@ -82,8 +82,20 @@ def generic_tekken8_importer(json_path, asset_name, asset_path, texture_root = '
         asset = try_create_asset(asset_path, asset_name, 'ItemPrefab')
         apply(asset, data)
         unreal.EditorAssetLibrary.save_loaded_asset(asset, False)
+    elif "ECI_" in asset_name:
+        asset = try_create_asset(asset_path, asset_name, 'EffectCharacterItem')
+        apply(asset, data)
+        unreal.EditorAssetLibrary.save_loaded_asset(asset, False)
+    elif "ACI_" in asset_name:
+        asset = try_create_asset(asset_path, asset_name, 'AuraCharacterItem')
+        apply(asset, data)
+        unreal.EditorAssetLibrary.save_loaded_asset(asset, False)
     elif "CI_" in asset_name:
         asset = try_create_asset(asset_path, asset_name, 'CustomizeItem')
+        apply(asset, data)
+        unreal.EditorAssetLibrary.save_loaded_asset(asset, False)
+    elif "CS_" in asset_name:
+        asset = try_create_asset(asset_path, asset_name, 'CustomizeSet')
         apply(asset, data)
         unreal.EditorAssetLibrary.save_loaded_asset(asset, False)
     elif "MI_" in asset_name:


### PR DESCRIPTION
Made this commit, due to needing the project to have a dummy for all the CS, IP, ECI and ACI. For making it easier to modify such presets, IPs, etc. instead of manually importing JSON files one by one.

- Included ECI, ACI, and CS on tekken8_import_utils
- Added ItemPrefabSet, BaseMakeItemSet and AuraEffectItems in ARRAY_TYPES
- Added ECI and ACI factories on MAP_TYPES